### PR TITLE
Add retry configuration with exponential backoff to SDK examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,29 @@ export CLIENT_ID="your_client_id"
 export CLIENT_SECRET="your_client_secret"
 ```
 
+### Retry Configuration
+
+The SDK supports automatic retry with exponential backoff using [urllib3's Retry](https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html#urllib3.util.Retry) class. Configure retries using the `retries` parameter in `Configuration`:
+
+```python
+from urllib3.util.retry import Retry
+from secure_access.configuration import Configuration
+from secure_access.api_client import ApiClient
+
+configuration = Configuration(
+    access_token=access_token,
+    retries=Retry(
+        total=3,  # Maximum number of retry attempts
+        backoff_factor=3,  # Wait time multiplier between retries: {backoff_factor} * (2 ** (retry_number - 1)) seconds. With factor=3: 0s, 3s, 6s delays
+        status_forcelist=[429],  # HTTP status codes that trigger a retry (429 = Too Many Requests / rate limited)
+        allowed_methods=["GET", "POST"]  # HTTP methods that are allowed to be retried
+    )
+)
+api_client = ApiClient(configuration=configuration)
+```
+
+To disable retry, omit the `retries` parameter or set it to `None`.
+
 ## Examples
 
 The `examples/` folder contains sample scripts demonstrating various use cases with the Cisco Secure Access SDK:

--- a/examples/access_rule_backup_restore.py
+++ b/examples/access_rule_backup_restore.py
@@ -7,7 +7,7 @@ from secure_access.api_client import ApiClient
 from access_token import generate_access_token
 from secure_access.configuration import Configuration
 from secure_access.models import PutRuleRequest
-from urllib3.util.retry import Retry
+from config import config
 from secure_access.models import AddRuleRequest
 import json, argparse, logging, sys
 
@@ -137,15 +137,6 @@ class AccessRulesBackupAndRestore:
 
 
 if __name__ == "__main__":
-    # Enable/disable automatic retry on rate limiting (429) with exponential backoff
-    ENABLE_RETRY = True
-    RETRIES = Retry(
-        total=3,  # Maximum number of retry attempts
-        backoff_factor=3,  # Wait time multiplier between retries: {backoff_factor} * (2 ** (retry_number - 1)) seconds. With factor=3: 0s, 3s, 6s delays
-        status_forcelist=[429],  # HTTP status codes that trigger a retry (429 = Too Many Requests / rate limited)
-        allowed_methods=["GET", "POST"]  # HTTP methods that are allowed to be retried
-    ) if ENABLE_RETRY else None
-
     parser=argparse.ArgumentParser(description="Utility to backup and restore access rules")
     
     #Adding optional parameters
@@ -186,12 +177,12 @@ if __name__ == "__main__":
         if args.offset != None and args.limit !=None:
             access_rule = AccessRulesBackupAndRestore(offset = args.offset, 
                                                       limit = args.limit,
-                                                      retries=RETRIES)
+                                                      retries=config.get_retry())
             isListRules = True
         elif args.rules:
-            access_rule = AccessRulesBackupAndRestore(rules = args.rules, retries=RETRIES)
+            access_rule = AccessRulesBackupAndRestore(rules = args.rules, retries=config.get_retry())
         else:
-            access_rule = AccessRulesBackupAndRestore(retries=RETRIES)
+            access_rule = AccessRulesBackupAndRestore(retries=config.get_retry())
             isListRules = True
 
         if isListRules:
@@ -219,7 +210,7 @@ if __name__ == "__main__":
         logger.info("Taking backup of all the rules.")
         access_rule.backup_access_rule_list()
     elif args.type == "restore":
-        access_rule = AccessRulesBackupAndRestore(retries=RETRIES)
+        access_rule = AccessRulesBackupAndRestore(retries=config.get_retry())
         logger.info("Parsing backed up access rules.")
         access_rule.parse_backup_access_rules()
         logger.info("Restoring the access rules.")

--- a/examples/config.py
+++ b/examples/config.py
@@ -1,0 +1,97 @@
+# Copyright 2025 Cisco Systems, Inc. and its affiliates
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from urllib3.util.retry import Retry
+
+
+class RetryConfig:
+    """Retry configuration for API requests using urllib3's Retry."""
+
+    def __init__(self, total=3, backoff_factor=3, status_forcelist=None, allowed_methods=None):
+        """Initialize retry configuration.
+
+        Args:
+            total: Maximum number of retry attempts.
+            backoff_factor: Wait time multiplier between retries:
+                {backoff_factor} * (2 ** (retry_number - 1)) seconds.
+            status_forcelist: HTTP status codes that trigger a retry.
+                Defaults to [429] for rate limiting.
+            allowed_methods: HTTP methods that are allowed to be retried.
+                Defaults to ["GET", "POST"].
+        """
+        self.total = total
+        self.backoff_factor = backoff_factor
+        self.status_forcelist = status_forcelist or [429]
+        self.allowed_methods = allowed_methods or ["GET", "POST"]
+
+    def build(self):
+        """Build urllib3 Retry object from configuration.
+
+        Returns:
+            urllib3.util.retry.Retry: Configured Retry object.
+        """
+        return Retry(
+            total=self.total,
+            backoff_factor=self.backoff_factor,
+            status_forcelist=self.status_forcelist,
+            allowed_methods=self.allowed_methods,
+        )
+
+
+class Config:
+    """Centralized configuration for examples.
+
+    Modify the values below to customize behavior across all examples.
+    """
+
+    def __init__(self):
+        """Initialize configuration with all options disabled."""
+        self._retry_config = None
+
+    def enable_retries(
+        self, total=3, backoff_factor=3, status_forcelist=None, allowed_methods=None
+    ):
+        """Enable retry with specified configuration.
+
+        Args:
+            total: Maximum number of retry attempts.
+            backoff_factor: Wait time multiplier between retries.
+            status_forcelist: HTTP status codes that trigger a retry.
+            allowed_methods: HTTP methods that are allowed to be retried.
+
+        Returns:
+            Config: Self for method chaining.
+        """
+        self._retry_config = RetryConfig(total, backoff_factor, status_forcelist, allowed_methods)
+        return self
+
+    def disable_retries(self):
+        """Disable retry.
+
+        Returns:
+            Config: Self for method chaining.
+        """
+        self._retry_config = None
+        return self
+
+    def get_retry(self):
+        """Get configured urllib3 Retry object.
+
+        Returns:
+            urllib3.util.retry.Retry or None: Retry object if enabled, None otherwise.
+        """
+        return self._retry_config.build() if self._retry_config else None
+
+
+# DEFAULT CONFIGURATION - Modify these values to change behavior across examples
+
+config = Config()
+
+# Enable retry with defaults (3 retries, 3s backoff, 429 status, GET/POST methods)
+config.enable_retries()
+# To customize retry settings:
+# config.enable_retries(total=5, backoff_factor=2, status_forcelist=[429, 503])
+
+# To disable retry:
+# config.disable_retries()

--- a/examples/destination_list_manager.py
+++ b/examples/destination_list_manager.py
@@ -6,7 +6,7 @@ from secure_access.api import destination_lists_api, destinations_api
 from secure_access.api_client import ApiClient
 from access_token import generate_access_token
 from secure_access.configuration import Configuration
-from urllib3.util.retry import Retry
+from config import config
 from secure_access.models import (
     DestinationListCreate,
     DestinationListPatch,
@@ -1745,15 +1745,6 @@ def handle_destinations(args, retries=None):
 
 
 if __name__ == "__main__":
-    # Enable/disable automatic retry on rate limiting (429) with exponential backoff
-    ENABLE_RETRY = True
-    RETRIES = Retry(
-        total=3,  # Maximum number of retry attempts
-        backoff_factor=3,  # Wait time multiplier between retries: {backoff_factor} * (2 ** (retry_number - 1)) seconds. With factor=3: 0s, 3s, 6s delays
-        status_forcelist=[429],  # HTTP status codes that trigger a retry (429 = Too Many Requests / rate limited)
-        allowed_methods=["GET", "POST"]  # HTTP methods that are allowed to be retried
-    ) if ENABLE_RETRY else None
-
     # Main parser
     parser = argparse.ArgumentParser(
         description="Cisco Secure Access Destination Management Tool"
@@ -1778,9 +1769,9 @@ if __name__ == "__main__":
 
     try:
         if args.command == "destination-lists":
-            handle_destination_lists(args, retries=RETRIES)
+            handle_destination_lists(args, retries=config.get_retry())
         elif args.command == "destinations":
-            handle_destinations(args, retries=RETRIES)
+            handle_destinations(args, retries=config.get_retry())
     except KeyboardInterrupt:
         logger.info("Operation cancelled by user")
         sys.exit(0)

--- a/examples/key_admin_api.py
+++ b/examples/key_admin_api.py
@@ -15,7 +15,7 @@ from access_token import generate_access_token
 from secure_access.configuration import Configuration
 from secure_access.api_client import ApiClient
 from secure_access.api import APIKeysApi, RoamingComputersApi
-from urllib3.util.retry import Retry
+from config import config
 from secure_access.models import (
     CreateAPIKeysRequest,
     PatchAPIKeyRequest,
@@ -213,16 +213,7 @@ class KeyAdminApi:
 
 
 if __name__ == "__main__":
-    # Enable/disable automatic retry on rate limiting (429) with exponential backoff
-    ENABLE_RETRY = True
-    RETRIES = Retry(
-        total=3,  # Maximum number of retry attempts
-        backoff_factor=3,  # Wait time multiplier between retries: {backoff_factor} * (2 ** (retry_number - 1)) seconds. With factor=3: 0s, 3s, 6s delays
-        status_forcelist=[429],  # HTTP status codes that trigger a retry (429 = Too Many Requests / rate limited)
-        allowed_methods=["GET", "POST"]  # HTTP methods that are allowed to be retried
-    ) if ENABLE_RETRY else None
-
-    key_admin_api = KeyAdminApi(retries=RETRIES)
+    key_admin_api = KeyAdminApi(retries=config.get_retry())
     try:
         print("Getting Secure Access API keys...")
         api_keys_response = key_admin_api.get_api_keys()
@@ -287,7 +278,7 @@ if __name__ == "__main__":
         )
         keyadmin_configuration = Configuration(
             access_token=keyadmin_access_token,
-            retries=RETRIES
+            retries=config.get_retry()
         )
         keyadmin_api_client = ApiClient(configuration=keyadmin_configuration)
         roaming_computers_api = RoamingComputersApi(api_client=keyadmin_api_client)

--- a/examples/roaming_computers_backup.py
+++ b/examples/roaming_computers_backup.py
@@ -6,7 +6,7 @@ from secure_access.api import roaming_computers_api
 from secure_access.api_client import ApiClient
 from access_token import generate_access_token
 from secure_access.configuration import Configuration
-from urllib3.util.retry import Retry
+from config import config
 import json, argparse, logging, sys, re
 from datetime import datetime, timedelta
 from typing import Dict, Any, List, Union
@@ -680,15 +680,6 @@ def parse_datetime(date_string: str) -> datetime:
 
 
 def main():
-    # Enable/disable automatic retry on rate limiting (429) with exponential backoff
-    ENABLE_RETRY = True
-    RETRIES = Retry(
-        total=3,  # Maximum number of retry attempts
-        backoff_factor=3,  # Wait time multiplier between retries: {backoff_factor} * (2 ** (retry_number - 1)) seconds. With factor=3: 0s, 3s, 6s delays
-        status_forcelist=[429],  # HTTP status codes that trigger a retry (429 = Too Many Requests / rate limited)
-        allowed_methods=["GET", "POST"]  # HTTP methods that are allowed to be retried
-    ) if ENABLE_RETRY else None
-
     parser = argparse.ArgumentParser(
         description="Utility to backup roaming computers and apply filters",
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -867,7 +858,7 @@ Examples:
         swg_status=args.swg_status,
         last_sync_before=last_sync_before,
         last_sync_after=last_sync_after,
-        retries=RETRIES
+        retries=config.get_retry()
     )
     
     # Set custom backup file if provided


### PR DESCRIPTION
Added configurable urllib3 retry support to SDK examples for handling rate limiting (HTTP 429). Examples now include an ENABLE_RETRY toggle with default configuration of 3 retries and 3-second exponential backoff. Updated README with retry usage documentation.

Screenshot:
<img width="1293" height="260" alt="image" src="https://github.com/user-attachments/assets/4df49fd6-82f8-49bc-a2b1-4b8afb073b2d" />